### PR TITLE
Closes 292  Fixed the edit product glitch.

### DIFF
--- a/app/routes/products.py
+++ b/app/routes/products.py
@@ -69,8 +69,7 @@ def create_product():
 @admin_permission.require()
 def edit_product(id):
     product = Product.query.filter_by(id=id).first()
-    product.stock_image_url = conn.get_URL(product.stock_image_url)
-    product.card_image_url = conn.get_URL(product.card_image_url)
+    
 
     if request.method == 'POST':
         product.name = request.form.get('name')
@@ -84,10 +83,14 @@ def edit_product(id):
         if large_file:
             large_file.filename = secure_filename(large_file.filename)
             large = conn.create(large_file)
+        else:
+            large = product.stock_image_url
         
         if small_file:
             small_file.filename = secure_filename(small_file.filename)
             small = conn.create(small_file)
+        else:
+            small = product.card_image_url
 
         product.stock_image_url = large if large and large != "" else '/static/images/test.png'
         product.card_image_url = small if small and small != "" else '/static/images/test.png'
@@ -95,6 +98,9 @@ def edit_product(id):
         db.session.commit()
 
         return redirect(url_for('product_blueprint.product', product_id=id))
+
+    product.stock_image_url = conn.get_URL(product.stock_image_url)
+    product.card_image_url = conn.get_URL(product.card_image_url)
 
     return render_template('products/product_edit.html', product=product)
 


### PR DESCRIPTION
there were two issues.  The first was obvious, if there was no change to the images, the small and large image variables were not being created.  To fix that, I created an else statement that defaults the large and small variables to the corresponding database product images.  If there isn't a change, we basically select the current data from the database.  

There was another issue as well.  The product images urls were being set to a conn.get_URL() right after the database query.  This was causing a non change data to be equal to a tokenized URL and bork the URL path when saving the image.  I simply moved this get_URL to the bottom, after image processing, but before the page render it was designed to serve.  This way, we use the original product data until we actually have to render the page, then we get the tokenized URLs at that point.